### PR TITLE
Fix WHERE parsing, LIMIT/OFFSET handling, and /query error response; add tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,11 +18,10 @@ app.add_url_rule('/logout', 'logout', logout_handler, methods=['POST'])
 def handle_query():
     data = request.get_json() or {}
     query = data.get('query', '')
-    try:
-        result = processor.process(query)
-        return jsonify(result)
-    except Exception as e:
-        return jsonify({'error': str(e)}), 400
+    result = processor.process(query)
+    if 'error' in result:
+        return jsonify(result), 400
+    return jsonify(result)
 
 @app.route('/tables', methods=['GET'])
 @login_required

--- a/datastore.py
+++ b/datastore.py
@@ -32,7 +32,7 @@ class DataStore:
     def _parse_where(self, where_clause):
         if not where_clause:
             return None, None, None
-        pattern = r"(\w+)\s*(=|!=|>|<|>=|<=|LIKE)\s*(.+)"
+        pattern = r"(\w+)\s*(>=|<=|!=|=|>|<|LIKE)\s*(.+)"
         m = re.match(pattern, where_clause, re.I)
         if not m:
             raise ValueError(f"Invalid WHERE clause: {where_clause}")
@@ -110,9 +110,9 @@ class DataStore:
             rows = sorted(rows, key=lambda x: x.get(col.lower()), reverse=reverse)
 
         # Pagination
-        if offset:
+        if offset is not None:
             rows = rows[offset:]
-        if limit:
+        if limit is not None:
             rows = rows[:limit]
 
         # Projection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_app_error_status.py
+++ b/tests/test_app_error_status.py
@@ -1,0 +1,16 @@
+from app import app
+
+
+def test_invalid_query_returns_bad_request_when_authenticated():
+    app.config.update(TESTING=True, SESSION_COOKIE_SECURE=False)
+
+    with app.test_client() as client:
+        login_response = client.post(
+            "/login", json={"username": "admin", "password": "password"}
+        )
+        assert login_response.status_code == 200
+
+        response = client.post("/query", json={"query": "BOGUS"})
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "Unsupported command: BOGUS"}

--- a/tests/test_limit_offset.py
+++ b/tests/test_limit_offset.py
@@ -1,0 +1,25 @@
+from query_processor import QueryProcessor
+
+
+def _seed_users():
+    processor = QueryProcessor()
+    processor.process("CREATE TABLE users(id, age);")
+    processor.process("INSERT INTO users(id, age) VALUES (1, 21);")
+    processor.process("INSERT INTO users(id, age) VALUES (2, 22);")
+    return processor
+
+
+def test_limit_zero_returns_no_rows():
+    processor = _seed_users()
+
+    result = processor.process("SELECT * FROM users LIMIT 0;")
+
+    assert result == {"data": []}
+
+
+def test_offset_zero_still_applies_limit():
+    processor = _seed_users()
+
+    result = processor.process("SELECT * FROM users LIMIT 1 OFFSET 0;")
+
+    assert result == {"data": [{"id": 1, "age": 21}]}

--- a/tests/test_where_operators.py
+++ b/tests/test_where_operators.py
@@ -1,0 +1,23 @@
+from query_processor import QueryProcessor
+
+
+def test_where_gte_operator_filters_correctly():
+    processor = QueryProcessor()
+    processor.process("CREATE TABLE users(id, age);")
+    processor.process("INSERT INTO users(id, age) VALUES (1, 29);")
+    processor.process("INSERT INTO users(id, age) VALUES (2, 30);")
+
+    result = processor.process("SELECT * FROM users WHERE age >= 30;")
+
+    assert result == {"data": [{"id": 2, "age": 30}]}
+
+
+def test_where_lte_operator_filters_correctly():
+    processor = QueryProcessor()
+    processor.process("CREATE TABLE users(id, age);")
+    processor.process("INSERT INTO users(id, age) VALUES (1, 29);")
+    processor.process("INSERT INTO users(id, age) VALUES (2, 30);")
+
+    result = processor.process("SELECT * FROM users WHERE age <= 29;")
+
+    assert result == {"data": [{"id": 1, "age": 29}]}


### PR DESCRIPTION
### Motivation
- Correct several bugs causing incorrect query behavior and HTTP responses: mis-parsed multi-character WHERE operators, incorrect handling of zero `LIMIT`/`OFFSET`, and the `/query` endpoint not propagating `QueryProcessor` errors as HTTP 400.
- Add regression tests to prevent regressions for these query and API behaviors.

### Description
- Adjusted the WHERE parser in `DataStore._parse_where` to match multi-character operators first by changing the regex to `r"(\w+)\s*(>=|<=|!=|=|>|<|LIKE)\s*(.+)"` so `>=` and `<=` are parsed correctly.
- Treated `limit` and `offset` as valid zero values by replacing truthy checks with `is not None` in `DataStore.select` to ensure `LIMIT 0` and `OFFSET 0` behave as expected.
- Updated the `/query` handler in `app.py` to return HTTP 400 when `QueryProcessor.process` returns an error payload by checking for the `'error'` key and returning `jsonify(result), 400`.
- Added test support and regression tests: `tests/conftest.py`, `tests/test_where_operators.py`, `tests/test_limit_offset.py`, and `tests/test_app_error_status.py` to cover the fixes.

### Testing
- Ran `pytest -q tests/test_where_operators.py` and it passed (covers `>=` and `<=` behavior).
- Ran `pytest -q tests/test_limit_offset.py` and it passed (covers `LIMIT 0` and `OFFSET 0`).
- Ran the full suite with `pytest -q` and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b573943804832091b410454af53262)